### PR TITLE
Remove warning about QEMU emulation on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ npm run ios
 
 ### Android
 
-> [!IMPORTANT]
-> You may experience problems running the app on an emulated Android device under QEMU due to https://github.com/holepunchto/libjs/issues/4. If you encounter crashes, try running the app on a real Android device instead.
-
 ```sh
 npm run android
 ```


### PR DESCRIPTION
Fixed in https://github.com/holepunchto/libjs/commit/25513fdade427be9877406cc768953241abc49b0

ht @AndreiRegiani for pointing it out